### PR TITLE
bug fix: "Cannot subset columns with a tuple with more than one eleme…

### DIFF
--- a/src/analysis.ipynb
+++ b/src/analysis.ipynb
@@ -35,7 +35,7 @@
     "feat = \"concatenated_fv\"\n",
     "control = \"session\"\n",
     "\n",
-    "df_group = df.groupby([control])[\"rotation\",feat]\n",
+    "df_group = df.groupby([control])[[\"rotation\",feat]]\n",
     "\n",
     "g_id = list(df_group.groups.keys())"
    ]


### PR DESCRIPTION

…nt." Updated analysis.ipynb

Fixed done based on the stack overflow suggestion: https://stackoverflow.com/questions/76158147/pandas-groupby-valueerror-cannot-subset-columns-with-a-tuple-with-more-than-o

<img width="1440" alt="Error Message Screenshot 2024-12-04 at 2 18 12 PM" src="https://github.com/user-attachments/assets/0d78003e-03f5-477d-855c-78d426939dc2">
